### PR TITLE
Notebook_helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN pip3 install --user \
         jupytext==1.11.4 \
         pytest==6.2.4 \
         black==21.7b0 \
+        papermill==2.3.3 \
         mypy==0.910 && \
     : && \
     : Add py-percent format support for Jupyter notebooks, see && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ RUN mkdir -p $MYPY_CACHE_DIR
 
 ENV PYTHONPYCACHEPREFIX=/home/host_user/.cache/pycache
 
-ENV PYTEST_ADDOPTS="-vvv -p no:cacheprovider"
+ENV PYTEST_ADDOPTS="-vvv -o cache_dir=/home/host_user/.cache/pytest"
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,5 +10,4 @@ ENV JUPYTER_TOKEN=$JUPYTER_TOKEN
 
 # See
 # https://docs.python.org/3/using/cmdline.html#environment-variables
-ENV PYTHONDEVMODE="1"
-ENV PYTHONDONTWRITEBYTECODE="1"
+# ENV PYTHONDEVMODE="1"

--- a/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 import tempfile, os
+from typing import Any, Dict
 
 #
-import jupytext
+import jupytext, papermill
 from nbconvert import HTMLExporter
 
 
@@ -11,6 +12,39 @@ class JupyterIpynbNotebook:
     def __init__(self, filepath: Path):
         assert filepath.suffix == ".ipynb"
         self.filepath = filepath
+
+    def evaluate(
+        self,
+        output: "JupyterIpynbNotebook",
+        cwd: Path,
+        parameters: Dict[str, Any],
+    ):
+        """
+        Evaluate this Jupyter notebook and write evaluated notebook to output_path.
+
+        Evaluation and parameters are injected using papermill (BSD licensed)
+        """
+        assert self.filepath.is_file()
+        assert not output.filepath.is_file()
+        assert cwd.is_dir()
+
+        # For all parameters, see
+        # https://github.com/nteract/papermill/blob/main/papermill/cli.py
+        # https://github.com/nteract/papermill/blob/main/papermill/execute.py
+
+        papermill.execute_notebook(
+            input_path=self.filepath,
+            output_path=output.filepath,
+            parameters=parameters,
+            request_save_on_cell_execute=True,
+            kernel_name="python",
+            language="python",
+            progress_bar=True,
+            stdout_file=None,
+            stderr_file=None,
+            log_output=True,
+            cwd=cwd,
+        )
 
     def to_html(self):
         """

--- a/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
@@ -46,17 +46,23 @@ class JupyterIpynbNotebook:
             cwd=cwd,
         )
 
-    def to_html(self):
+    def to_html(self) -> Path:
         """
-        Convert this ipynb notebook into an html file
+        Convert this ipynb notebook into an html file.
+
+        Return Path of output html file.
 
         See unit tests in nbconvert (BSD licensed):
         https://github.com/jupyter/nbconvert/blob/main/nbconvert/exporters/tests/test_html.py
         """
         assert self.filepath.is_file()
 
+        output_filepath = self.filepath.with_suffix(".html")
+
         output, _ = HTMLExporter(template_name="classic").from_filename(self.filepath)
-        self.filepath.with_suffix(".html").write_text(output)
+        output_filepath.write_text(output)
+
+        return output_filepath
 
     @staticmethod
     def temp(path: Path) -> "JupyterIpynbNotebook":

--- a/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+#
+import jupytext
+
+
+class JupyterIpynbNotebook:
+    # ipynb is the default file format used by Jupyter for storing notebooks.
+    def __init__(self, filepath: Path):
+        assert filepath.suffix == ".ipynb"
+        self.filepath = filepath
+
+
+class JupytextNotebook:
+    """
+    For details about the Jupytext Jupyter-plugin and file format, see:
+       https://jupytext.readthedocs.io
+    """
+
+    def __init__(self, filepath: Path):
+        assert filepath.suffix == ".py"
+        self.filepath = filepath
+
+    def to_jupyter_ipynb_notebook(self, output: JupyterIpynbNotebook):
+        """
+        Notes:
+        This method only converts one file format to another, and no code cells are
+        evaluated. Thus all cells outputs in the output ipynb file will be empty.
+
+        However, cell inputs (code and tags) from input Jupytext notebook are
+        included in the output ipynb notebook.
+        """
+
+        # see https://jupytext.readthedocs.io/en/latest/using-library.html
+        nb = jupytext.read(self.filepath, fmt="py:percent")
+        jupytext.write(nb, fp=output.filepath, fmt="notebook")

--- a/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import tempfile, os
 
 #
 import jupytext
@@ -9,6 +10,24 @@ class JupyterIpynbNotebook:
     def __init__(self, filepath: Path):
         assert filepath.suffix == ".ipynb"
         self.filepath = filepath
+
+    @staticmethod
+    def temp(path: Path) -> "JupyterIpynbNotebook":
+        """
+        Return a JupyterIpynbNotebook with a (random) non-existent filename in the
+        provided path.
+        """
+        assert path.is_dir()
+
+        fp, tmp_filepath = tempfile.mkstemp(
+            dir=path,
+            prefix="temp-notebook-",
+            suffix=".ipynb",
+        )
+        os.close(fp)
+        os.remove(tmp_filepath)
+
+        return JupyterIpynbNotebook(Path(tmp_filepath))
 
 
 class JupytextNotebook:

--- a/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
@@ -3,6 +3,7 @@ import tempfile, os
 
 #
 import jupytext
+from nbconvert import HTMLExporter
 
 
 class JupyterIpynbNotebook:
@@ -10,6 +11,18 @@ class JupyterIpynbNotebook:
     def __init__(self, filepath: Path):
         assert filepath.suffix == ".ipynb"
         self.filepath = filepath
+
+    def to_html(self):
+        """
+        Convert this ipynb notebook into an html file
+
+        See unit tests in nbconvert (BSD licensed):
+        https://github.com/jupyter/nbconvert/blob/main/nbconvert/exporters/tests/test_html.py
+        """
+        assert self.filepath.is_file()
+
+        output, _ = HTMLExporter(template_name="classic").from_filename(self.filepath)
+        self.filepath.with_suffix(".html").write_text(output)
 
     @staticmethod
     def temp(path: Path) -> "JupyterIpynbNotebook":

--- a/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/notebooks_helpers.py
@@ -93,7 +93,7 @@ class JupytextNotebook:
         assert filepath.suffix == ".py"
         self.filepath = filepath
 
-    def to_jupyter_ipynb_notebook(self, output: JupyterIpynbNotebook):
+    def to_ipynb(self):
         """
         Notes:
         This method only converts one file format to another, and no code cells are
@@ -102,7 +102,10 @@ class JupytextNotebook:
         However, cell inputs (code and tags) from input Jupytext notebook are
         included in the output ipynb notebook.
         """
+        output = JupyterIpynbNotebook(self.filepath.with_suffix(".ipynb"))
 
         # see https://jupytext.readthedocs.io/en/latest/using-library.html
         nb = jupytext.read(self.filepath, fmt="py:percent")
         jupytext.write(nb, fp=output.filepath, fmt="notebook")
+
+        return output

--- a/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import os
+
+#
+from pynb_dag_runner.notebooks_helpers import JupytextNotebook, JupyterIpynbNotebook
+from pynb_dag_runner.helpers import read_json
+
+# Example content of a Jupyter notebook stored in the py-percent file format.
+TEST_JUPYTEXT_NOTEBOOK = """# %%
+# %% tags=["parameters"]
+# %%
+print(1 + 12 + 123)
+# %%
+"""
+
+
+def write_test_jupytext_notebook(path: Path) -> JupytextNotebook:
+    notebook_py = JupytextNotebook(path / "notebook.py")
+
+    with open(notebook_py.filepath, "tw") as f:
+        f.write(TEST_JUPYTEXT_NOTEBOOK)
+
+    assert os.path.getsize(notebook_py.filepath) == len(TEST_JUPYTEXT_NOTEBOOK)
+    return notebook_py
+
+
+def test_can_convert_jupytext_notebook_to_ipynb(tmp_path: Path):
+    notebook_py: JupytextNotebook = write_test_jupytext_notebook(tmp_path)
+
+    # Convert py-percent jupytext file into ipynb-notebook file format
+    notebook_ipynb = JupyterIpynbNotebook(tmp_path / "notebook.ipynb")
+    notebook_py.to_jupyter_ipynb_notebook(notebook_ipynb)
+
+    # assert that generated ipynb file exists and parses as json
+    assert notebook_ipynb.filepath.is_file()
+    assert isinstance(read_json(notebook_ipynb.filepath)["cells"], list)

--- a/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
@@ -34,3 +34,10 @@ def test_can_convert_jupytext_notebook_to_ipynb(tmp_path: Path):
     # assert that generated ipynb file exists and parses as json
     assert notebook_ipynb.filepath.is_file()
     assert isinstance(read_json(notebook_ipynb.filepath)["cells"], list)
+
+
+def test_random_ipynb_notebook_path(tmp_path: Path):
+    notebook_ipynb = JupyterIpynbNotebook.temp(tmp_path)
+
+    assert not notebook_ipynb.filepath.is_file()
+    assert str(notebook_ipynb.filepath).startswith(str(tmp_path))

--- a/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
@@ -39,8 +39,7 @@ def test_can_convert_jupytext_notebook_to_ipynb_and_html(tmp_path: Path):
     assert isinstance(read_json(notebook_ipynb.filepath)["cells"], list)
 
     # assert that this ipynb can be converted into html
-    notebook_ipynb.to_html()
-    filepath_html = notebook_ipynb.filepath.with_suffix(".html")
+    filepath_html = notebook_ipynb.to_html()
     assert filepath_html.is_file()
     assert "# Example comment" in filepath_html.read_text()
 

--- a/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
@@ -18,21 +18,18 @@ print(f"variable_a={variable_a}")
 
 
 def write_test_jupytext_notebook(path: Path) -> JupytextNotebook:
-    notebook_py = JupytextNotebook(path / "notebook.py")
+    output_path = path / "notebook.py"
+    output_path.write_text(TEST_JUPYTEXT_NOTEBOOK)
 
-    with open(notebook_py.filepath, "tw") as f:
-        f.write(TEST_JUPYTEXT_NOTEBOOK)
-
-    assert os.path.getsize(notebook_py.filepath) == len(TEST_JUPYTEXT_NOTEBOOK)
-    return notebook_py
+    assert os.path.getsize(output_path) == len(TEST_JUPYTEXT_NOTEBOOK)
+    return JupytextNotebook(output_path)
 
 
 def test_can_convert_jupytext_notebook_to_ipynb_and_html(tmp_path: Path):
     notebook_py: JupytextNotebook = write_test_jupytext_notebook(tmp_path)
 
     # Convert py-percent jupytext file into ipynb-notebook file format
-    notebook_ipynb = JupyterIpynbNotebook(tmp_path / "notebook.ipynb")
-    notebook_py.to_jupyter_ipynb_notebook(notebook_ipynb)
+    notebook_ipynb = notebook_py.to_ipynb()
 
     # assert that generated ipynb file exists and parses as json
     assert notebook_ipynb.filepath.is_file()
@@ -48,8 +45,7 @@ def test_can_convert_jupytext_notebook_to_ipynb_and_evaluate(tmp_path: Path):
     notebook_py: JupytextNotebook = write_test_jupytext_notebook(tmp_path)
 
     # Convert py-percent jupytext file into ipynb-notebook file format
-    notebook_ipynb = JupyterIpynbNotebook(tmp_path / "notebook.ipynb")
-    notebook_py.to_jupyter_ipynb_notebook(notebook_ipynb)
+    notebook_ipynb = notebook_py.to_ipynb()
 
     # Evaluation ipynb notebook
     notebook_eval_ipynb = JupyterIpynbNotebook(tmp_path / "notebook_evaluated.ipynb")

--- a/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
@@ -12,6 +12,8 @@ TEST_JUPYTEXT_NOTEBOOK = """# %%
 # Example comment
 print(1 + 12 + 123)
 # %%
+print(f"variable_a={variable_a}")
+# %%
 """
 
 
@@ -25,7 +27,7 @@ def write_test_jupytext_notebook(path: Path) -> JupytextNotebook:
     return notebook_py
 
 
-def test_can_convert_jupytext_notebook_to_ipynb(tmp_path: Path):
+def test_can_convert_jupytext_notebook_to_ipynb_and_html(tmp_path: Path):
     notebook_py: JupytextNotebook = write_test_jupytext_notebook(tmp_path)
 
     # Convert py-percent jupytext file into ipynb-notebook file format
@@ -41,6 +43,23 @@ def test_can_convert_jupytext_notebook_to_ipynb(tmp_path: Path):
     filepath_html = notebook_ipynb.filepath.with_suffix(".html")
     assert filepath_html.is_file()
     assert "# Example comment" in filepath_html.read_text()
+
+
+def test_can_convert_jupytext_notebook_to_ipynb_and_evaluate(tmp_path: Path):
+    notebook_py: JupytextNotebook = write_test_jupytext_notebook(tmp_path)
+
+    # Convert py-percent jupytext file into ipynb-notebook file format
+    notebook_ipynb = JupyterIpynbNotebook(tmp_path / "notebook.ipynb")
+    notebook_py.to_jupyter_ipynb_notebook(notebook_ipynb)
+
+    # Evaluation ipynb notebook
+    notebook_eval_ipynb = JupyterIpynbNotebook(tmp_path / "notebook_evaluated.ipynb")
+    notebook_ipynb.evaluate(
+        output=notebook_eval_ipynb, cwd=tmp_path, parameters={"variable_a": "hello"}
+    )
+
+    assert notebook_eval_ipynb.filepath.is_file()
+    assert "variable_a=hello" in notebook_eval_ipynb.filepath.read_text()
 
 
 def test_random_ipynb_notebook_path(tmp_path: Path):

--- a/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_notebook_helpers.py
@@ -9,6 +9,7 @@ from pynb_dag_runner.helpers import read_json
 TEST_JUPYTEXT_NOTEBOOK = """# %%
 # %% tags=["parameters"]
 # %%
+# Example comment
 print(1 + 12 + 123)
 # %%
 """
@@ -34,6 +35,12 @@ def test_can_convert_jupytext_notebook_to_ipynb(tmp_path: Path):
     # assert that generated ipynb file exists and parses as json
     assert notebook_ipynb.filepath.is_file()
     assert isinstance(read_json(notebook_ipynb.filepath)["cells"], list)
+
+    # assert that this ipynb can be converted into html
+    notebook_ipynb.to_html()
+    filepath_html = notebook_ipynb.filepath.with_suffix(".html")
+    assert filepath_html.is_file()
+    assert "# Example comment" in filepath_html.read_text()
 
 
 def test_random_ipynb_notebook_path(tmp_path: Path):


### PR DESCRIPTION
- classes for working with Jupytext and Jupyter notebook files
- support: 
  - evaluation of notebooks (using papermill)
  - conversion of jupytext notebook -> ipynb and ipnb -> html (using nbconvert)
- enable caching (python bytecode and pytest). This made unit tests for these tasks much faster (~4.5 secs to 1 sec)