### PR TITLE
Include dependency list to wheel file

### DIFF
--- a/workspace/pynb_dag_runner/setup.py
+++ b/workspace/pynb_dag_runner/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from pathlib import Path
 
 setup(
     name="pynb_dag_runner",
@@ -10,5 +11,8 @@ setup(
     ],
     url="https://github.com/pynb-dag-runner/pynb-dag-runner",
     version="0.0.1",
+    install_requires=(
+        Path("/home/host_user/requirements.base.txt").read_text().split("\n")
+    ),
     packages=find_packages(exclude=("tests",)),
 )


### PR DESCRIPTION
Now dependencies like Ray and Jupytext are installed when running `pip install <pynb-wheel-file>`.