### PR TITLE
delete/refactor more unit tests to new task API

### DIFF
--- a/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
+++ b/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
@@ -29,7 +29,7 @@ def test__task_ot__async_wait_for_task():
 
     task = task_from_python_function(f, tags={"foo": "f"})
 
-    [outcome] = start_and_await_tasks([task], [task], timeout_s=10)
+    [outcome] = start_and_await_tasks([task], [task], timeout_s=30)
 
     assert isinstance(outcome, TaskOutcome)
     assert outcome.error is None
@@ -80,7 +80,7 @@ def test__task_ot__task_orchestration__run_three_tasks_in_sequence():
                 assert ray.get(task.has_started.remote()) == False
                 assert ray.get(task.has_completed.remote()) == False
 
-            [outcome] = start_and_await_tasks([task_f], [task_h], timeout_s=10)
+            [outcome] = start_and_await_tasks([task_f], [task_h], timeout_s=30)
 
             assert isinstance(outcome, TaskOutcome)
             assert outcome.error is None

--- a/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
+++ b/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
@@ -6,27 +6,16 @@ import pytest, ray
 
 #
 from pynb_dag_runner.core.dag_runner import (
-    Task,
     RemoteTaskP,
-    task_from_python_function,
     TaskOutcome,
-    TaskDependencies,
+    task_from_python_function,
     run_in_sequence,
     fan_in,
-    run_tasks,
     start_and_await_tasks,
 )
 from pynb_dag_runner.opentelemetry_helpers import (
     SpanId,
     get_span_id,
-    has_keys,
-    read_key,
-    is_parent_child,
-    get_duration_s,
-    iso8601_to_epoch_s,
-    get_duration_range_us,
-    get_span_exceptions,
-    Span,
     SpanDict,
     Spans,
     SpanRecorder,

--- a/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
+++ b/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
@@ -33,71 +33,10 @@ from pynb_dag_runner.opentelemetry_helpers import (
 )
 from pynb_dag_runner.helpers import A, one
 
-#
-from tests.test_ray_helpers import StateActor
-
-
-@pytest.mark.parametrize(
-    "task_dependencies",
-    [
-        "[]",
-        "[task0 >> task1]",
-        "[task1 >> task0]",
-        "[task1 >> task0, task1 >> task2]",
-        "[task0 >> task1, task1 >> task2]",
-        "[task0 >> task1, task1 >> task2, task0 >> task2]",
-    ],
-)
-def test_all_tasks_are_run(task_dependencies):
-    def make_task(sleep_secs: float, return_value: int) -> Task[int]:
-        @ray.remote(num_cpus=0)
-        def f(_):
-            time.sleep(sleep_secs)
-            return return_value
-
-        return Task(f.remote)
-
-    task0 = make_task(sleep_secs=0.05, return_value=0)
-    task1 = make_task(sleep_secs=0.01, return_value=1)
-    task2 = make_task(sleep_secs=0.025, return_value=2)
-
-    result = run_tasks(
-        [task0, task1, task2], TaskDependencies(*eval(task_dependencies))
-    )
-    assert len(result) == 3 and set(result) == set([0, 1, 2])
-
-
-@pytest.mark.parametrize("dummy_loop_parameter", range(1))
-def test_task_run_order(dummy_loop_parameter):
-    state_actor = StateActor.remote()
-
-    def make_task(i: int) -> Task[int]:
-        @ray.remote(num_cpus=0)
-        def f(_):
-            time.sleep(random.random() * 0.10)
-            state_actor.add.remote(i)
-
-        return Task(f.remote)
-
-    task0, task1, task2 = [make_task(i) for i in range(3)]
-
-    _ = run_tasks(
-        [task0, task1, task2], TaskDependencies(task1 >> task0, task2 >> task0)
-    )
-
-    state = ray.get(state_actor.get.remote())
-    assert len(state) == 3
-
-    # task0 should run last while run order of task1 and task2 is random
-    assert state[0] in [1, 2]
-    assert state[1] in [1, 2]
-    assert state[2] == 0
-
 
 def test__task_ot__async_wait_for_task():
     def f(_):
-        time.sleep(0.125)
-        return 43
+        return 42
 
     task = task_from_python_function(f, tags={"foo": "f"})
 
@@ -105,7 +44,7 @@ def test__task_ot__async_wait_for_task():
 
     assert isinstance(outcome, TaskOutcome)
     assert outcome.error is None
-    assert outcome.return_value == 43
+    assert outcome.return_value == 42
 
 
 def dependency_span__to__from_to_ids(dep_span: SpanDict) -> Tuple[SpanId, SpanId]:
@@ -320,7 +259,6 @@ def test__task_ot__task_orchestration__run_three_tasks_in_parallel__failed():
         return sr.spans
 
     def validate_spans(spans: Spans):
-        # TODO: no dependency information is now logged from parallel tasks
         deps = spans.filter(["name"], "task-dependency").sort_by_start_time()
         assert len(deps) == 0
 

--- a/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
+++ b/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
@@ -242,44 +242,95 @@ def test__python_function_task__otel_logs_for_stuck_task():
     validate_spans(get_test_spans())
 
 
-def _get_time_range(spans: Spans, span_id: str):
+def _get_time_range(spans: Spans, function_id: str, inner: bool):
     task_top_span = one(
-        spans.filter(["name"], "invoke-task")
+        spans.filter(["name"], "execute-task")
         # -
-        .filter(["attributes", "task_id"], span_id)
+        .filter(["attributes", "tags.function_id"], function_id)
     )
 
-    return get_duration_range_us(task_top_span)
+    task_spans = spans.restrict_by_top(task_top_span)
+
+    inner_flag_to_span_dict = {
+        # inner=True: return time range for span used for (inner) python
+        # function call; this is where task cpu resources are reserved.
+        True: one(task_spans.filter(["name"], "call-python-function")),
+        # inner=False: return time range for top span of entire task
+        False: task_top_span,
+    }
+
+    return get_duration_range_us(inner_flag_to_span_dict[inner])
 
 
 def test_tasks_run_in_parallel():
     def get_test_spans():
         with SpanRecorder() as rec:
-            dependencies = TaskDependencies()
+            tasks = [
+                task_from_python_function(
+                    lambda _: time.sleep(1.0),
+                    tags={"function_id": f"id#{function_id}"},
+                    timeout_s=10.0,
+                )
+                for function_id in range(2)
+            ]
 
-            run_tasks(
-                [
-                    PythonFunctionTask_OT(lambda _: time.sleep(1.0), task_id="t0"),
-                    PythonFunctionTask_OT(lambda _: time.sleep(1.0), task_id="t1"),
-                ],
-                dependencies,
-            )
+            _ = start_and_await_tasks(tasks, tasks, timeout_s=10.0, arg="dummy value")
 
-        return rec.spans, get_task_dependencies(dependencies)
+        return rec.spans
 
-    def validate_spans(spans: Spans, task_dependencies):
-        assert len(spans.filter(["name"], "invoke-task")) == 2
+    def validate_spans(spans: Spans):
+        assert len(spans.filter(["name"], "execute-task")) == 2
 
-        t0_us_range = _get_time_range(spans, "t0")
-        t1_us_range = _get_time_range(spans, "t1")
+        t0_us_range = _get_time_range(spans, "id#0", inner=False)
+        t1_us_range = _get_time_range(spans, "id#1", inner=False)
 
         # Check: since there are no order constraints, the time ranges should
         # overlap provided tests are run on 2+ CPUs
         assert range_intersect(t0_us_range, t1_us_range)
 
-        assert_compatibility(spans, task_dependencies)
+        # assert_compatibility(spans)
 
-    validate_spans(*get_test_spans())
+    validate_spans(get_test_spans())
+
+
+def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
+    def get_test_spans():
+        with SpanRecorder() as rec:
+            tasks = [
+                task_from_python_function(
+                    lambda _: time.sleep(0.5),
+                    tags={"function_id": f"id#{function_id}"},
+                    timeout_s=10.0,
+                )
+                for function_id in range(4)
+            ]
+
+            start_ts = time.time_ns()
+            _ = start_and_await_tasks(tasks, tasks, timeout_s=10.0, arg="dummy value")
+            end_ts = time.time_ns()
+
+            # Check 1: with only 2 CPU:s running the above tasks with no constraints
+            # should take > 1 secs.
+            duration_ms = (end_ts - start_ts) // 1000000
+            assert duration_ms >= 1000, duration_ms
+        return rec.spans
+
+    def validate_spans(spans: Spans):
+        assert len(spans.filter(["name"], "execute-task")) == 4
+
+        task_runtime_ranges = [
+            _get_time_range(spans, span_id, inner=True)
+            for span_id in [f"id#{function_id}" for function_id in range(4)]
+        ]
+
+        # Check 2: if tasks are run on 2 CPU:s the intersection of three runtime ranges
+        # should always be empty.
+        for r1, r2, r3 in itertools.combinations(task_runtime_ranges, 3):
+            assert range_is_empty(range_intersection(r1, range_intersection(r2, r3)))
+
+        # assert_compatibility(spans)
+
+    validate_spans(get_test_spans())
 
 
 def test_always_failing_task():
@@ -310,48 +361,6 @@ def test_always_failing_task():
 
         run_spans = spans.filter(["name"], "task-run")
         assert len(run_spans) == 10
-
-        assert_compatibility(spans, task_dependencies)
-
-    validate_spans(*get_test_spans())
-
-
-def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
-    def get_test_spans():
-        with SpanRecorder() as rec:
-            start_ts = time.time_ns()
-
-            dependencies = TaskDependencies()
-            run_tasks(
-                [
-                    PythonFunctionTask_OT(lambda _: time.sleep(0.5), task_id="t0"),
-                    PythonFunctionTask_OT(lambda _: time.sleep(0.5), task_id="t1"),
-                    PythonFunctionTask_OT(lambda _: time.sleep(0.5), task_id="t2"),
-                    PythonFunctionTask_OT(lambda _: time.sleep(0.5), task_id="t3"),
-                ],
-                dependencies,
-            )
-
-            end_ts = time.time_ns()
-
-            # Check 1: with only 2 CPU:s running the above tasks with no constraints
-            # should take > 1 secs.
-            duration_ms = (end_ts - start_ts) // 1000000
-            assert duration_ms >= 1000, duration_ms
-
-        return rec.spans, get_task_dependencies(dependencies)
-
-    def validate_spans(spans: Spans, task_dependencies):
-        assert len(spans.filter(["name"], "invoke-task")) == 4
-
-        task_runtime_ranges = [
-            _get_time_range(spans, span_id) for span_id in ["t0", "t1", "t2", "t3"]
-        ]
-
-        # Check 2: if tasks are run on 2 CPU:s the intersection of three runtime ranges
-        # should always be empty.
-        for r1, r2, r3 in itertools.combinations(task_runtime_ranges, 3):
-            assert range_is_empty(range_intersection(r1, range_intersection(r2, r3)))
 
         assert_compatibility(spans, task_dependencies)
 

--- a/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
+++ b/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
@@ -6,7 +6,6 @@ import pytest
 
 #
 from pynb_dag_runner.tasks.tasks import (
-    PythonFunctionTask,
     PythonFunctionTask_OT,
     RunParameters,
     get_task_dependencies,
@@ -274,7 +273,7 @@ def test_tasks_run_in_parallel():
                 for function_id in range(2)
             ]
 
-            _ = start_and_await_tasks(tasks, tasks, timeout_s=10.0, arg="dummy value")
+            _ = start_and_await_tasks(tasks, tasks, timeout_s=30.0, arg="dummy value")
 
         return rec.spans
 
@@ -306,7 +305,7 @@ def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
             ]
 
             start_ts = time.time_ns()
-            _ = start_and_await_tasks(tasks, tasks, timeout_s=10.0, arg="dummy value")
+            _ = start_and_await_tasks(tasks, tasks, timeout_s=30.0, arg="dummy value")
             end_ts = time.time_ns()
 
             # Check 1: with only 2 CPU:s running the above tasks with no constraints

--- a/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
+++ b/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
@@ -308,8 +308,8 @@ def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
             _ = start_and_await_tasks(tasks, tasks, timeout_s=30.0, arg="dummy value")
             end_ts = time.time_ns()
 
-            # Check 1: with only 2 CPU:s running the above tasks with no constraints
-            # should take > 1 secs.
+            # Check 1: with only 2 CPU:s (reserved for unit tests, see ray.init call)
+            # running the above tasks with no constraints should take > 1 secs.
             duration_ms = (end_ts - start_ts) // 1000000
             assert duration_ms >= 1000, duration_ms
         return rec.spans
@@ -322,8 +322,8 @@ def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
             for span_id in [f"id#{function_id}" for function_id in range(4)]
         ]
 
-        # Check 2: if tasks are run on 2 CPU:s the intersection of three runtime ranges
-        # should always be empty.
+        # Check 2: since only 2 CPU:s are reserved (for unit tests, see above)
+        # the intersection of three runtime ranges should always be empty.
         for r1, r2, r3 in itertools.combinations(task_runtime_ranges, 3):
             assert range_is_empty(range_intersection(r1, range_intersection(r2, r3)))
 


### PR DESCRIPTION
main changes:

- delete `test_all_tasks_are_run(task_dependencies`
- delete `test_task_run_order(dummy_loop_parameter`
- moved `test_tasks_run_in_parallel` and `test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus` to new API