### PR TITLE
cli-tool: write logged metrics to run-jsons 

### DIFF
--- a/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
@@ -86,6 +86,13 @@ def read_json(filepath: Path) -> Any:
 
 
 def write_json(filepath: Path, obj: Any):
+    """
+    Write object as JSON object to filepath (and create directories if needed).
+    """
+
+    # ensure base directory for filepath exists
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
     with open(filepath, "w") as f:
         json.dump(obj, f, indent=2)
 

--- a/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
@@ -105,7 +105,7 @@ def read_jsonl(path: Path):
 
 def one(xs: Sequence[A]) -> A:
     """
-    Assert that argument can be converted into list with only one element, and
+    Assert that input can be converted into list with only one element, and
     return that element.
     """
     xs_list = list(xs)

--- a/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
@@ -105,7 +105,7 @@ def read_jsonl(path: Path):
 
 def one(xs: Sequence[A]) -> A:
     """
-    Assert that input can be converted into list with only one element, and
+    Assert that argument can be converted into list with only one element, and
     return that element.
     """
     xs_list = list(xs)

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Tuple, Set, List
+from typing import Any, Iterable, Mapping, MutableMapping, Tuple, Set, List
 
 #
 from pynb_dag_runner.opentelemetry_helpers import Spans, SpanId, get_duration_s
@@ -93,7 +93,7 @@ def add_html_notebook_artefacts(artefacts: List[ArtefactDict]) -> List[ArtefactD
 
 
 def _get_logged_named_values(spans: Spans, task_run_top_span) -> Mapping[str, Any]:
-    result: Mapping[str, Any] = {}
+    result: MutableMapping[str, Any] = {}
 
     for artefact_span in (
         spans.bound_under(task_run_top_span)

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
@@ -102,7 +102,7 @@ def _run_iterator(
             "attributes": (
                 spans.bound_inclusive(task_run_top_span)
                 #
-                .get_attributes(allowed_prefixes={"run."})
+                .get_attributes(allowed_prefixes={"run.", "task.", "pipeline."})
             ),
         }
         yield run_dict, _artefact_iterator(spans, task_run_top_span)
@@ -117,7 +117,7 @@ def _task_iterator(spans: Spans) -> Iterable[Tuple[TaskDict, Iterable[RunDict]]]
             "attributes": (
                 spans.bound_inclusive(task_top_span)
                 #
-                .get_attributes(allowed_prefixes={"task."})
+                .get_attributes(allowed_prefixes={"task.", "pipeline."})
             ),
         }
 

--- a/workspace/pynb_dag_runner/pynb_log_parser/cli.py
+++ b/workspace/pynb_dag_runner/pynb_log_parser/cli.py
@@ -22,7 +22,6 @@ def write_to_output_dir(spans: Spans, output_basepath: Path):
 
     pipeline_dict, task_it = get_pipeline_iterators(spans)
 
-    output_basepath.mkdir(parents=True, exist_ok=True)
     write_json(output_basepath / "pipeline.json", pipeline_dict)
 
     for task_dict, task_retry_it in task_it:
@@ -43,7 +42,6 @@ def write_to_output_dir(spans: Spans, output_basepath: Path):
 
         task_basepath: Path = output_basepath / task_subdir
 
-        task_basepath.mkdir(parents=True, exist_ok=True)
         write_json(task_basepath / "task.json", task_dict)
 
         print("*** task: ", task_dict)
@@ -57,7 +55,6 @@ def write_to_output_dir(spans: Spans, output_basepath: Path):
                 ]
             )
 
-            run_basepath.mkdir(parents=True, exist_ok=True)
             write_json(run_basepath / "run.json", task_run_dict)
 
             print("     *** run: ", task_run_dict)

--- a/workspace/pynb_dag_runner/tests/test_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_helpers.py
@@ -94,12 +94,12 @@ def test_pairs():
 
 
 def test_write_read_json(tmp_path: Path):
-    test_obj = [42, {"42": [0, None, []]}]
-    test_path = tmp_path / "test.json"
+    for _ in range(4):
+        test_obj = [42, {"42": [0, None, []]}]
+        test_path = tmp_path / "directories"/ "that-should" / "be-created" / "test.json"
 
-    write_json(test_path, test_obj)
-    assert read_json(test_path) == test_obj
-
+        write_json(test_path, test_obj)
+        assert read_json(test_path) == test_obj
 
 def test_one():
     assert one([1]) == 1

--- a/workspace/pynb_dag_runner/tests/test_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_helpers.py
@@ -96,10 +96,13 @@ def test_pairs():
 def test_write_read_json(tmp_path: Path):
     for _ in range(4):
         test_obj = [42, {"42": [0, None, []]}]
-        test_path = tmp_path / "directories"/ "that-should" / "be-created" / "test.json"
+        test_path = (
+            tmp_path / "directories" / "that-should" / "be-created" / "test.json"
+        )
 
         write_json(test_path, test_obj)
         assert read_json(test_path) == test_obj
+
 
 def test_one():
     assert one([1]) == 1


### PR DESCRIPTION
- inc. slight refactor of cli tool
- revise content of task and run json:s 
   - task-dict also include pipeline attributes
   - run-dict also include task and pipeline attributes
   - run-dict also include logged values during that run