### PR TITLE
Merge ci_utils repo into `otel_output_parser` directory

### DIFF
--- a/otel_output_parser/.devcontainer-docker-compose.yml
+++ b/otel_output_parser/.devcontainer-docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  dev-environment:
+    image: ci-tools-image
+    volumes:
+    - ./workspace:/home/host_user/workspace
+    command:
+    - tail -f /dev/null
+    hostname: ci-tools-image

--- a/otel_output_parser/.devcontainer.json
+++ b/otel_output_parser/.devcontainer.json
@@ -1,0 +1,15 @@
+// See, https://code.visualstudio.com/docs/remote/containers
+{
+  "name": "ci-tools-image dev",
+  "dockerComposeFile": [
+    ".devcontainer-docker-compose.yml"
+  ],
+  "service": "dev-environment",
+  "runServices": [],
+  "forwardPorts": [],
+  "remoteEnv": {},
+  "extensions": [
+    "ms-python.python"
+  ],
+  "workspaceFolder": "/home/host_user/workspace",
+}

--- a/otel_output_parser/.vscode/extensions.json
+++ b/otel_output_parser/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers"
+    ]
+}

--- a/otel_output_parser/LICENSE.md
+++ b/otel_output_parser/LICENSE.md
@@ -1,9 +1,0 @@
-### [MIT-License](https://opensource.org/licenses/MIT)
-
-Copyright 2021-2022, Matias Dahl - except where otherwise noted.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/otel_output_parser/LICENSE.md
+++ b/otel_output_parser/LICENSE.md
@@ -1,0 +1,9 @@
+### [MIT-License](https://opensource.org/licenses/MIT)
+
+Copyright 2021-2022, Matias Dahl - except where otherwise noted.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/otel_output_parser/README.md
+++ b/otel_output_parser/README.md
@@ -39,6 +39,3 @@ Individual tasks are run as eg `task docker:build`.
 
 - Inside Docker dev-container, the `code:watch-all` task can be run using
   "Ctrl + Shift + P" -> "Run Task" and select the "code:watch-all" task.
-
-## License
-(c) Matias Dahl 2021-2022, MIT, see [LICENSE.md](./LICENSE.md).

--- a/otel_output_parser/README.md
+++ b/otel_output_parser/README.md
@@ -1,0 +1,44 @@
+# ci-utils
+Utils/scripts for running pynb-dag-runner in Github actions and processing output run logs
+
+## Local setup
+(Tested on Ubuntu system)
+
+### Taskfile
+This project uses [Taskfile](https://taskfile.dev/) (a yaml-based tool similar to makefile)
+for common project task definitions.
+
+### Installation
+For install instructions, see `https://taskfile.dev/#/installation`.
+
+Eg., if `~/.local/bin` is in `$PATH`, Taskfile can be installed for the user as:
+```bash
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+```
+
+Verify that the Taskfile is installed by running `task --version`.
+
+### List of project tasks
+After taskfile is installed, running `task --list` shows a list of available tasks:
+
+```
+task: Available tasks for this project:
+* code:black: 		Check that code is Black formatted (black)
+* code:mypy: 		Check static mypy type checks (mypy)
+* code:pytest: 		Run unit tests (pytest)
+* code:watch-all: 	Watch all tests in tmux session
+* docker:build: 	Build project Docker image
+* docker:run: 		Run bash command in project Docker image (interactive if IS_INTERACTIVE=true)
+* docker:shell: 	Start an interactive shell in project Docker image
+```
+
+Individual tasks are run as eg `task docker:build`.
+
+## VS Code development
+- Set up VS Code (TBD)
+
+- Inside Docker dev-container, the `code:watch-all` task can be run using
+  "Ctrl + Shift + P" -> "Run Task" and select the "code:watch-all" task.
+
+## License
+(c) Matias Dahl 2021-2022, MIT, see [LICENSE.md](./LICENSE.md).

--- a/otel_output_parser/Taskfile.yml
+++ b/otel_output_parser/Taskfile.yml
@@ -1,0 +1,38 @@
+version: "3"
+
+includes:
+  docker: ./docker/Taskfile.yml
+
+vars:
+  # unless set, assume WATCH_MODE is false
+  WATCH_MODE: '{{if eq .WATCH_MODE "true"}}true{{else}}false{{end}}'
+
+tasks:
+  "code:pytest":
+    desc: Run unit tests (pytest)
+    cmds:
+      - task: docker:run
+        vars:
+          CLI_ARGS: "task pytest WATCH_MODE={{.WATCH_MODE}}"
+
+  "code:mypy":
+    desc: Check static mypy type checks (mypy)
+    cmds:
+      - task: docker:run
+        vars:
+          CLI_ARGS: "task mypy WATCH_MODE={{.WATCH_MODE}}"
+
+  "code:black":
+    desc: Check that code is Black formatted (black)
+    cmds:
+      - task: docker:run
+        vars:
+          CLI_ARGS: "task black WATCH_MODE={{.WATCH_MODE}}"
+
+  "code:watch-all":
+    desc: Watch all tests in tmux session
+    cmds:
+      - task: docker:run
+        vars:
+          CLI_ARGS: "task watch-all"
+          IS_INTERACTIVE: "true"

--- a/otel_output_parser/docker/Dockerfile.base
+++ b/otel_output_parser/docker/Dockerfile.base
@@ -1,0 +1,41 @@
+FROM ubuntu:20.04
+
+ARG HOST_GID
+ARG HOST_UID
+
+ENV DEBIAN_FRONTEND "noninteractive"
+
+RUN apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get install -y -q \
+        curl \
+        python3 \
+        python3-pip \
+        entr \
+        tmuxinator
+
+RUN groupadd --gid $HOST_GID host_user_group  && \
+    useradd --uid $HOST_UID --gid $HOST_GID -rm --shell /bin/bash host_user
+
+USER host_user
+ENV PATH "/home/host_user/.local/bin:$PATH"
+
+ENV PYTHONPYCACHEPREFIX=/home/host_user/.cache/python
+
+RUN pip3 install --user \
+        pytest==6.2.5 \
+        black==21.12b0 \
+        mypy==0.930 \
+        ghapi==0.1.19 \
+        requests==2.27.1
+
+
+# Install Taskfile, see https://taskfile.dev/#/installation
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+ENV MYPY_CACHE_DIR=/home/host_user/.cache/mypy
+RUN mkdir -p $MYPY_CACHE_DIR
+
+ENV PYTEST_ADDOPTS="-o cache_dir=/home/host_user/.cache/pytest"
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/otel_output_parser/docker/Taskfile.yml
+++ b/otel_output_parser/docker/Taskfile.yml
@@ -1,0 +1,83 @@
+version: "3"
+
+vars:
+  DOCKER_IMAGE: ci-tools-image
+
+tasks:
+  build:
+    desc: Build project Docker image
+    vars:
+      HOST_UID: {sh: "id -u"}
+      HOST_GID: {sh: "id -g"}
+    cmds:
+      - |
+        docker build \
+          --file docker/Dockerfile.base \
+          --build-arg HOST_UID={{.HOST_UID}} \
+          --build-arg HOST_GID={{.HOST_GID}} \
+          --tag {{.DOCKER_IMAGE}} \
+          .
+
+  # ----
+  # It seems that the "interactive" setting in Taskfile can not be set dynamically.
+  # Therefore we define two (internal) tasks as below.
+  #
+  # See:
+  #   https://taskfile.dev/#/usage?id=interactive-cli-application
+  #
+  # Since these tasks have no descriptions, the do not show up in "task --list"
+  run-interactive-true:
+    cmds:
+      - |
+        {{if eq .IS_INTERACTIVE "true"}}
+          {{.COMMAND}}
+        {{else}}
+          : skipped
+        {{end}}
+    interactive: true
+
+  run-interactive-false:
+    cmds:
+      - |
+        {{if eq .IS_INTERACTIVE "false"}}
+          {{.COMMAND}}
+        {{else}}
+          : skipped
+        {{end}}
+    interactive: false
+
+  run:
+    desc: Run bash command in project Docker image (interactive if IS_INTERACTIVE=true)
+    # Eg.
+    #   task docker:run -- "ls -al ."
+    #   task docker:run -- "(printenv; pip3 freeze)"
+    vars:
+      # if IS_INTERACTIVE is not set, assume false
+      IS_INTERACTIVE: '{{if eq .IS_INTERACTIVE "true"}}true{{else}}false{{end}}'
+      INTERACTIVE_SWITCH: '{{if eq .IS_INTERACTIVE "true"}}-i{{else}}{{end}}'
+      COMMAND: |
+        docker run --rm -t \
+          {{.INTERACTIVE_SWITCH}} \
+          --network none \
+          --volume {{.PWD}}/workspace:/home/host_user/workspace \
+          --workdir /home/host_user/workspace/ \
+          {{.DOCKER_IMAGE}} \
+          "{{.CLI_ARGS}}"
+
+    cmds:
+      - task: run-interactive-false
+        vars:
+          COMMAND: "{{.COMMAND}}"
+          IS_INTERACTIVE: "{{.IS_INTERACTIVE}}"
+      - task: run-interactive-true
+        vars:
+          COMMAND: "{{.COMMAND}}"
+          IS_INTERACTIVE: "{{.IS_INTERACTIVE}}"
+
+  shell:
+    desc: Start an interactive shell in project Docker image
+    cmds:
+      - task: run
+        vars:
+          IS_INTERACTIVE: "true"
+          CLI_ARGS: '/bin/bash' # this is not ideal, we are running "bash -c /bin/bash"

--- a/otel_output_parser/workspace/.tmux.conf
+++ b/otel_output_parser/workspace/.tmux.conf
@@ -1,0 +1,4 @@
+# Add mouse support, https://stackoverflow.com/questions/11832199
+# Newer versions of VS Code should also support this, see
+# https://github.com/microsoft/vscode/issues/96058
+set -g mouse on

--- a/otel_output_parser/workspace/.tmuxinator.yml
+++ b/otel_output_parser/workspace/.tmuxinator.yml
@@ -1,0 +1,16 @@
+# See, https://github.com/tmuxinator/tmuxinator
+
+name: watch_tests
+root: ~/workspace/
+
+tmux_options: -f .tmux.conf
+
+startup_window: watch_tests
+
+windows:
+  - watch_tests:
+      layout: main-vertical
+      panes:
+        - task pytest WATCH_MODE=true
+        - task mypy WATCH_MODE=true
+        - task black WATCH_MODE=true

--- a/otel_output_parser/workspace/.vscode/extensions.json
+++ b/otel_output_parser/workspace/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}

--- a/otel_output_parser/workspace/.vscode/settings.json
+++ b/otel_output_parser/workspace/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+    // Editor settings
+    "window.zoomLevel": 0,
+    "editor.fontSize": 18,
+    "editor.rulers": [
+        88
+    ],
+    "editor.renderWhitespace": "all",
+    "editor.renderLineHighlight": "all",
+    "editor.formatOnSave": true,
+    "workbench.colorCustomizations": {
+        "editor.lineHighlightBackground": "#484860",
+        "editorWhitespace.foreground": "#525260"
+    },
+    // Python settings
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.formatting.provider": "black",
+    "python.formatting.blackPath": "/home/host_user/.local/bin/black",
+    "python.formatting.blackArgs": [],
+    "jupyter.jupyterServerType": "local",
+    // Extensions settings
+    //
+    // VS Code have had issues installing extensions when VS Code is run inside a
+    // container. This should have been fixed, but the below seems to work better (?)
+    // See https://github.com/microsoft/vscode/issues/119073
+    "remote.downloadExtensionsLocally": true,
+    // Terminal settings
+    "terminal.integrated.fontSize": 11,
+    "terminal.integrated.cwd": "/home/host_user/workspace"
+}

--- a/otel_output_parser/workspace/.vscode/tasks.json
+++ b/otel_output_parser/workspace/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "code:watch-all - watch all Python tests",
+            "type": "shell",
+            "command": "task watch-all",
+            "group": "none",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new",
+            },
+            "isBackground": true,
+            "problemMatcher": []
+        },
+    ]
+}

--- a/otel_output_parser/workspace/Taskfile.yml
+++ b/otel_output_parser/workspace/Taskfile.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+vars:
+  WATCH_MODE: '{{.WATCH_MODE}}'
+  WATCH_COMMAND: '{{if eq .WATCH_MODE "true"}}find . | grep ".py" | entr{{else}}{{end}}'
+
+tasks:
+  pytest:
+    desc: Run unit tests (pytest)
+    cmds:
+      - '{{.WATCH_COMMAND}} bash -c "(date; pytest -vvv tests)"'
+
+  mypy:
+    desc: Check static mypy type checks (mypy)
+    cmds:
+      - "{{.WATCH_COMMAND}} mypy static_builder tests"
+
+  black:
+    desc: Check that code is Black formatted (black)
+    cmds:
+      - "{{.WATCH_COMMAND}} black --check --diff ."
+
+  watch-all:
+    desc: Watch unit tests, mypy static tests and black formatting (in tmux session)
+    # exit with Ctrl-B + "kill-session"
+    cmds:
+      - "tmuxinator start"

--- a/otel_output_parser/workspace/setup.py
+++ b/otel_output_parser/workspace/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="pynb_dag_runner_ciutils",
+    author="Matias Dahl",
+    author_email="matias.dahl@iki.fi",
+    license="MIT",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
+    entry_points={
+        "console_scripts": [
+            "static_builder = static_builder.cli:entry_point",
+        ],
+    },
+    url="https://github.com/pynb-dag-runner",
+    version="0.0.1",
+    install_requires=[],
+    packages=find_packages(exclude=["tests", "tests.*"]),
+)

--- a/otel_output_parser/workspace/static_builder/cli.py
+++ b/otel_output_parser/workspace/static_builder/cli.py
@@ -1,0 +1,54 @@
+from typing import Any
+from pathlib import Path
+from argparse import ArgumentParser
+
+from .github_helpers import list_artifacts_for_repo, download_artifact
+from .static_builder import process_artifact
+
+# `static_builder` command line utility --- run `statuc_builder --help` for usage
+
+
+def args():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--github_repository",
+        required=True,
+        type=str,
+        help="Github repo owner and name. eg. myorg/myrepo",
+    )
+    parser.add_argument(
+        "--output_dir",
+        required=True,
+        type=str,
+        help="Output directory",
+    )
+    return parser.parse_args()
+
+
+def entry_point():
+
+    github_repository = args().github_repository
+    if len(github_repository.split("/")) != 2:
+        raise ValueError("github_repository parameter should be in format owner/repo-name")
+
+    gh_repo_owner, gh_repo_name = github_repository.split("/")
+
+    output_dir = args().output_dir
+
+    print("gh_repo_owner   :", gh_repo_owner)
+    print("gh_repo_name    :", gh_repo_name)
+    print("output_dir      :", output_dir)
+
+    results = list_artifacts_for_repo(repo_owner=gh_repo_owner, repo_name=gh_repo_name)
+    for idx, entry in enumerate(results):
+        if entry["expired"]:
+            continue
+        print(idx, entry)
+
+        artefact_zip = download_artifact(
+            repo_owner=gh_repo_owner,
+            repo_name=gh_repo_name,
+            artifact_id=entry["id"],
+        )
+
+        process_artifact(artefact_zip, output_dir=Path(output_dir))

--- a/otel_output_parser/workspace/static_builder/github_helpers.py
+++ b/otel_output_parser/workspace/static_builder/github_helpers.py
@@ -1,0 +1,83 @@
+import os
+from typing import Dict, List, Iterable
+
+#
+
+# For full list of ghapi methods, see https://ghapi.fast.ai/fullapi.html
+from ghapi.all import GhApi  # type: ignore
+import requests  # type: ignore
+
+
+def _paginator(operation, per_page=30, **kwargs) -> Iterable[Dict]:
+    """
+    Paginator-wrapper suitable for getting all results from list_artifacts_for_repo api.
+
+    The GhApi library has built in pagainator-wrapper (from ghapi.page import paged).
+    This is described here: https://ghapi.fast.ai/page.html
+
+    However, this wrapper seems to loop over a fixed number of pages (default 9999)
+    even when there is less data. This issue is known, see
+    https://github.com/fastai/ghapi/issues/96  which also includes a workaround.
+    However, this does not seem to work for list_artifacts_for_repo since
+    "incomplete_results" is not a key in results returned from this api.
+    """
+    count = 0
+    for page in range(1, 9999):
+        result = operation(**kwargs, per_page=per_page, page=page)
+        # assert "incomplete_results" not in result
+
+        if len(result["artifacts"]) == 0:
+            break
+        for entry in result["artifacts"]:
+            yield dict(entry)
+            count += 1
+
+    assert count == result["total_count"]
+
+
+def list_artifacts_for_repo(repo_owner: str, repo_name: str) -> List[Dict]:
+    """
+    List all artefacts in a Github repo.
+
+    Environment variable GITHUB_TOKEN should contain valid token (either token
+    generated for an action run, or a Github personal access token).
+
+    The required scope for the token is documented here:
+    https://docs.github.com/en/rest/reference/actions#artifacts
+
+    See above link for strucuture of return values.
+    """
+    api = GhApi()
+
+    return list(
+        _paginator(
+            api.actions.list_artifacts_for_repo, owner=repo_owner, repo=repo_name
+        )
+    )
+
+
+def download_artifact(repo_owner: str, repo_name: str, artifact_id: int) -> bytes:
+    """
+    Download artifact from Github repo
+
+    API Documentation
+    https://docs.github.com/en/rest/reference/actions#download-an-artifact
+
+    Note:
+     - download artifact api did not seem to work with GhApi library
+    """
+    token = os.getenv("GITHUB_TOKEN")
+    if token is None:
+        raise Exception("GITHUB_TOKEN should be set")
+
+    endpoint = "https://api.github.com/repos/"
+    url = f"{repo_owner}/{repo_name}/actions/artifacts/{artifact_id}/zip"
+    response = requests.get(
+        endpoint + url,
+        headers={"authorization": f"Bearer {token}"},
+        allow_redirects=True,
+    )
+    if response.status_code != requests.codes.ok:
+        raise Exception(f"Request failed with code {response.status_code}")
+
+    return response.content

--- a/otel_output_parser/workspace/static_builder/static_builder.py
+++ b/otel_output_parser/workspace/static_builder/static_builder.py
@@ -1,0 +1,135 @@
+import io, json
+
+from typing import Any, List, Dict, Tuple, Union
+from pathlib import Path
+from zipfile import ZipFile
+
+
+# ---- Implement get_pipeline_artifacts from content of zip file ----
+
+PipelineArtifacts = Dict[str, bytes]
+TaskArtifacts = Dict[str, bytes]
+RunArtifacts = Dict[str, bytes]
+
+
+def _directories_under(z, prefix: str) -> List[str]:
+    return [
+        filepath.filename
+        for filepath in z.filelist
+        if filepath.filename.startswith(prefix)
+        and filepath.is_dir()
+        and Path(filepath.filename).parent == Path(prefix)
+    ]
+
+
+def _get_run_artifacts(z: ZipFile, task_run_directory: str) -> Dict[str, bytes]:
+    run_dir = Path(task_run_directory)
+    run_artifacts = {
+        str(Path(filepath.filename).relative_to(run_dir)): z.read(filepath)
+        for filepath in z.filelist
+        if filepath.filename.startswith(task_run_directory) and not filepath.is_dir()
+    }
+    assert "run.json" in run_artifacts
+    return run_artifacts
+
+
+def _get_task_artifacts(
+    z: ZipFile, task_directory: str
+) -> Tuple[TaskArtifacts, List[RunArtifacts]]:
+    task_artifacts = {"task.json": z.read(task_directory + "task.json")}
+
+    assert "task.json" in task_artifacts
+    return task_artifacts, [
+        _get_run_artifacts(z, d) for d in _directories_under(z, task_directory)
+    ]
+
+
+def get_pipeline_artifacts(
+    zipfile: Union[Path, bytes],
+) -> Tuple[PipelineArtifacts, List[Tuple[TaskArtifacts, List[RunArtifacts]]]]:
+    """
+    Analogous to function with same name in the main repo. However, this takes as
+    input a zip file where json/artifacts have been stored in a directory hierarchy.
+    """
+
+    if isinstance(zipfile, bytes):
+        z_io: Union[Path, io.BytesIO] = io.BytesIO(zipfile)
+    elif isinstance(zipfile, Path):
+        z_io = zipfile
+    else:
+        raise ValueError(f"Unknown zipfile input type {type(zipfile)}")
+
+    with ZipFile(z_io, "r") as z:  # type: ignore
+
+        pipeline_artifacts = {
+            Path(filepath).name: z.read(filepath)
+            for filepath in [
+                "pipeline-outputs/pipeline.json",
+                "dag-diagram.png",
+                "gantt-diagram.png",
+            ]
+        }
+        assert "pipeline.json" in pipeline_artifacts
+
+        # We return nested lists (and not iterators). This allows us to close the
+        # zipfile before returning.
+        return pipeline_artifacts, [
+            _get_task_artifacts(z, d) for d in _directories_under(z, "pipeline-outputs")
+        ]
+
+
+# ---- process one zip file; write artifacts/jsons to directory structure ----
+
+
+def bytes_to_json(b: bytes) -> Any:
+    return json.loads(b.decode("utf-8"))
+
+
+def ensure_dir_exist(p: Path) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def process_artifact(zip_content: bytes, output_dir: Path):
+    pipeline_artefacts, task_iterator = get_pipeline_artifacts(zip_content)
+    pipeline_id: str = (
+        bytes_to_json(pipeline_artefacts["pipeline.json"])
+        # -
+        ["attributes"]["pipeline.pipeline_run_id"]
+    )
+
+    print()
+    print(f"pipeline-id {pipeline_id}")
+
+    for k, v in pipeline_artefacts.items():
+        print(f" - writing pipeline-artefact {k} ({len(v)} bytes)")
+        ensure_dir_exist(output_dir / "pipeline" / pipeline_id / k).write_bytes(v)
+
+    for task_artefacts, run_iterator in task_iterator:
+        task_id: str = bytes_to_json(task_artefacts["task.json"])["span_id"]
+        print(f"    - task_id {task_id}*")
+
+        for k, v in task_artefacts.items():
+            print(f"      writing task-artefact {k} ({len(v)} bytes)")
+            ensure_dir_exist(
+                output_dir / "pipeline" / pipeline_id / "task" / task_id / k
+            ).write_bytes(v)
+
+        for run_artefacts in run_iterator:
+            run_id: str = bytes_to_json(run_artefacts["run.json"])["span_id"]
+            print(f"       - run_id {run_id}")
+
+            for k, v in run_artefacts.items():
+                print(f"         writing run-artefact {k} ({len(v)}) bytes)")
+                ensure_dir_exist(
+                    output_dir
+                    / "pipeline"
+                    / pipeline_id
+                    / "task"
+                    / task_id
+                    / "run"
+                    / run_id
+                    / k
+                ).write_bytes(v)
+
+    print("Done. Processed all pipeline, task and run:s")

--- a/otel_output_parser/workspace/tests/test_dummy.py
+++ b/otel_output_parser/workspace/tests/test_dummy.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_single_assert():
+    assert 1 == 1
+
+
+@pytest.mark.parametrize("x", range(10))
+def test_dummy_parameterized_test(x):
+    assert 0 <= x < 10


### PR DESCRIPTION
- Merge main branch from https://github.com/pynb-dag-runner/ci-utils repo (+the commit history) into this repo under the `otel_output_parser` directory
- Following instructions from here
  - https://blog.jdriven.com/2021/04/how-to-merge-multiple-git-repositories/
  - https://www.nomachetejuggling.com/2011/09/12/moving-one-git-repo-into-another-as-subdirectory/