### PR TITLE
Fix version of fastcore dependency

### DIFF
--- a/otel_output_parser/docker/Dockerfile.base
+++ b/otel_output_parser/docker/Dockerfile.base
@@ -27,6 +27,7 @@ RUN pip3 install --user \
         pytest==6.2.5 \
         black==22.3.0 \
         mypy==0.930 \
+        fastcore==1.4.3 \
         ghapi==0.1.19 \
         requests==2.27.1 \
         python-dateutil==2.8.2


### PR DESCRIPTION
Building static website started to fail today;

https://github.com/pynb-dag-runner/mnist-digits-demo-pipeline/actions/runs/2634377975

with error

```
   File "/home/host_user/.local/lib/python3.8/site-packages/ghapi/core.py", line 108, in __call__
    res,self.recv_hdrs = urlsend(path, verb, headers=headers or None, debug=self.debug, return_headers=True,
NameError: name 'urlsend' is not defined
```

Fix version of `fastcore`; longer term one should likely remove dependency on ghpages (?) it is not used for all API calls.