### PR TITLE
Revert "Remove the unused `all_children_ids` field from OpenTelemetry logs"

### DIFF
--- a/otel_output_parser/workspace/static_builder/cli.py
+++ b/otel_output_parser/workspace/static_builder/cli.py
@@ -179,6 +179,7 @@ class StaticMLFlowDataSink:
             summary["id"]: {
                 **del_key(summary, "id"),
                 "metadata": to_epoch(summary["type"], summary["metadata"]),
+                "all_children_ids": list(g.all_children_of(summary["id"])),
             }
             for summary in self.summaries
         }


### PR DESCRIPTION
This reverts commit 8f05eb8dadc69fcc75d6c12958c350da58044583.

`all_children_ids` is used and can not yet be removed