### PR TITLE
More general `flatten`; reorg helper functions

### DIFF
--- a/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, TypeVar, List, Iterable, Sequence, Tuple, Optio
 
 A = TypeVar("A")
 
-# --- range related helper functions ---
+# --- range helper functions ---
 
 
 def range_is_empty(range):
@@ -35,7 +35,7 @@ def range_intersect(range1, range2) -> bool:
     return not range_is_empty(range_intersection(range1, range2))
 
 
-# --- sequence and function helper functions ---
+# --- sequence helper functions ---
 
 
 def _is_iterable(maybe_iterable):
@@ -54,6 +54,37 @@ def flatten(xss):
             result.append(xs)
 
     return result
+
+
+def pairs(xs: Sequence[A]) -> Sequence[Tuple[A, A]]:
+    """
+    From a list of entries return list of subsequent entries.
+
+    The function assumes the input list has at least 2 entries.
+
+    Eg. [1, 2, 3, 4] -> [(1, 2), (2, 3), (3, 4)]
+    """
+    if len(xs) <= 1:
+        return []
+    return list(zip(xs[:-1], xs[1:]))
+
+
+def one(xs: Iterable[A]) -> A:
+    """
+    Assert that input can be converted into list with only one element, and
+    return that element.
+    """
+    xs_list = list(xs)
+    if not len(xs_list) == 1:
+        raise Exception(
+            "one: Expected input with only one element, "
+            f"but input has length {len(xs_list)}."
+        )
+
+    return xs_list[0]
+
+
+# --- function helper functions ---
 
 
 def compose(*fs):
@@ -75,60 +106,6 @@ def compose(*fs):
         return lambda *xs: compose(*fs_outers)(f_innermost(*xs))
     else:
         return f_innermost
-
-
-def pairs(xs: Sequence[A]) -> Sequence[Tuple[A, A]]:
-    """
-    From a list of entries return list of subsequent entries.
-
-    The function assumes the input list has at least 2 entries.
-
-    Eg. [1, 2, 3, 4] -> [(1, 2), (2, 3), (3, 4)]
-    """
-    if len(xs) <= 1:
-        return []
-    return list(zip(xs[:-1], xs[1:]))
-
-
-# --- file I/O helper functions ---
-
-
-def read_json(filepath: Path) -> Any:
-    with open(filepath, "r") as f:
-        return json.load(f)
-
-
-def write_json(filepath: Path, obj: Any):
-    """
-    Write object as JSON object to filepath (and create directories if needed).
-    """
-
-    # ensure base directory for filepath exists
-    filepath.parent.mkdir(parents=True, exist_ok=True)
-
-    with open(filepath, "w") as f:
-        json.dump(obj, f, indent=2)
-
-
-def read_jsonl(path: Path):
-    assert path.is_file()
-
-    return [json.loads(span_line) for span_line in path.read_text().splitlines()]
-
-
-def one(xs: Iterable[A]) -> A:
-    """
-    Assert that input can be converted into list with only one element, and
-    return that element.
-    """
-    xs_list = list(xs)
-    if not len(xs_list) == 1:
-        raise Exception(
-            "one: Expected input with only one element, "
-            f"but input has length {len(xs_list)}."
-        )
-
-    return xs_list[0]
 
 
 class Try(Generic[A]):
@@ -157,3 +134,29 @@ class Try(Generic[A]):
             return self_tuple == other_tuple
         else:
             return False
+
+
+# --- file I/O helper functions ---
+
+
+def read_json(filepath: Path) -> Any:
+    with open(filepath, "r") as f:
+        return json.load(f)
+
+
+def write_json(filepath: Path, obj: Any):
+    """
+    Write object as JSON object to filepath (and create directories if needed).
+    """
+
+    # ensure base directory for filepath exists
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(filepath, "w") as f:
+        json.dump(obj, f, indent=2)
+
+
+def read_jsonl(path: Path):
+    assert path.is_file()
+
+    return [json.loads(span_line) for span_line in path.read_text().splitlines()]

--- a/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/helpers.py
@@ -4,6 +4,8 @@ from typing import Any, Generic, TypeVar, List, Iterable, Sequence, Tuple, Optio
 
 A = TypeVar("A")
 
+# --- range related helper functions ---
+
 
 def range_is_empty(range):
     assert range.step == 1
@@ -33,15 +35,23 @@ def range_intersect(range1, range2) -> bool:
     return not range_is_empty(range_intersection(range1, range2))
 
 
+# --- sequence and function helper functions ---
+
+
+def _is_iterable(maybe_iterable):
+    # see: https://stackoverflow.com/questions/1952464
+    # In particular, this should return False for strings
+    return isinstance(maybe_iterable, (set, tuple, list))
+
+
 def flatten(xss):
-    assert isinstance(xss, list)
     result = []
 
     for xs in xss:
-        if isinstance(xs, list):
+        if _is_iterable(xs):
             result += flatten(xs)
         else:
-            result += [xs]
+            result.append(xs)
 
     return result
 
@@ -78,6 +88,9 @@ def pairs(xs: Sequence[A]) -> Sequence[Tuple[A, A]]:
     if len(xs) <= 1:
         return []
     return list(zip(xs[:-1], xs[1:]))
+
+
+# --- file I/O helper functions ---
 
 
 def read_json(filepath: Path) -> Any:

--- a/workspace/pynb_dag_runner/tests/test_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_helpers.py
@@ -17,6 +17,8 @@ from pynb_dag_runner.helpers import (
     pairs,
 )
 
+# --- range helper functions ---
+
 
 def test_range_empty():
     assert range_is_empty(range(0, 0))
@@ -56,6 +58,9 @@ def test_ranges():
     assert range_is_empty(range_intersection(range(1, 10), range(100, 1000)))
 
 
+# --- sequence helper functions ---
+
+
 def test_flatten():
     def flatten2(xss):
         assert flatten(flatten(xss)) == flatten(xss)
@@ -81,6 +86,26 @@ def test_flatten():
     assert flatten2(["abc", ("bar", "zoo")]) == ["abc", "bar", "zoo"]
 
 
+def test_pairs():
+    assert pairs([]) == []
+    assert pairs([1]) == []
+    assert pairs([1, 2]) == [(1, 2)]
+    assert pairs([1, 2, 3]) == [(1, 2), (2, 3)]
+    assert pairs([1, 2, 3, 4]) == [(1, 2), (2, 3), (3, 4)]
+
+
+def test_one():
+    assert one([1]) == 1
+
+
+def test_one_raises_exception():
+    with pytest.raises(Exception):
+        assert one([1, 2])
+
+
+# --- function helper functions ---
+
+
 def test_compose():
     f0 = lambda: f"f0()"
     f = lambda x: f"f({x})"
@@ -98,12 +123,7 @@ def test_compose():
     assert compose(h2)("u", "v") == "h2(u, v)" == h2("u", "v")
 
 
-def test_pairs():
-    assert pairs([]) == []
-    assert pairs([1]) == []
-    assert pairs([1, 2]) == [(1, 2)]
-    assert pairs([1, 2, 3]) == [(1, 2), (2, 3)]
-    assert pairs([1, 2, 3, 4]) == [(1, 2), (2, 3), (3, 4)]
+# --- file I/O helper functions ---
 
 
 def test_write_read_json(tmp_path: Path):
@@ -115,12 +135,3 @@ def test_write_read_json(tmp_path: Path):
 
         write_json(test_path, test_obj)
         assert read_json(test_path) == test_obj
-
-
-def test_one():
-    assert one([1]) == 1
-
-
-def test_one_raises_exception():
-    with pytest.raises(Exception):
-        assert one([1, 2])

--- a/workspace/pynb_dag_runner/tests/test_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_helpers.py
@@ -62,10 +62,23 @@ def test_flatten():
         return flatten(xss)
 
     assert flatten2([]) == flatten2([[]]) == flatten2([[], [], [[]]]) == []
+
+    assert flatten2([None, (None, None, [None])]) == [None, None, None, None]
     assert flatten2([1, [2]]) == [1, 2]
     assert flatten2([1, [2], [[[3]]]]) == [1, 2, 3]
     assert flatten2([[1, 2, 3, [4]]]) == [1, 2, 3, 4]
-    assert flatten2(list(range(10))) == list(range(10))
+
+    # should accept list, tuples, and sets
+    for t in [list, tuple, set]:
+        assert flatten2(t(range(10))) == list(range(10))
+        assert flatten2(t([])) == []
+
+    # mixed types
+    r1 = flatten2([(99, 22), {(1, 2), (3, 4), (4, 5)}])
+    assert list(sorted(r1)) == [1, 2, 3, 4, 4, 5, 22, 99]
+
+    # strings should not be expanded
+    assert flatten2(["abc", ("bar", "zoo")]) == ["abc", "bar", "zoo"]
 
 
 def test_compose():


### PR DESCRIPTION
- allow `flatten` for list, tuples and sets (but not strings). Previously only list:s were allowed.
- reorder and reorg functions (and tests) for `helper.py`  