### PR TITLE
Move to (faster) graph based Span parsing

### DIFF
--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -370,7 +370,7 @@ class Spans:
 
         return self._cached_graph
 
-    def contains_path(self, *span_chain: Span, recursive: bool = True) -> bool:
+    def contains_path(self, *span_chain: Span) -> bool:
         """
         Return true/false depending on whether there is a parent-child relationship
         link between the spans in span_chain.
@@ -381,6 +381,8 @@ class Spans:
         Cycles in self are not detected.
         """
         assert len(span_chain) >= 2
+
+        recursive = True
 
         if len(span_chain) == 2:
             parent, child = span_chain

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -401,7 +401,7 @@ class Spans:
                 self.contains_path(*ps, recursive=recursive) for ps in pairs(span_chain)
             )
 
-    def _bound_by(self, top: SpanDict, inclusive: bool = False) -> "Spans":
+    def _bound_by(self, top: SpanDict, inclusive: bool) -> "Spans":
         """
         Bound this span collection to spans that can be connected to
         the top-span using one or many parent-child relationships.

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -195,8 +195,8 @@ class UDT(Generic[NodeId]):
            v  v  v
            3  4  5
 
-    We will frequently omit the arrows and draw the tree with understanding that if
-    A and B are connected and A is above B then A is parent, and B is child node.
+    We can omit the arrows and draw the tree with understanding that if
+    (A and B are connected) and (A is above B), then A is parent, and B is child node.
     Then the above graph can be drawn as:
 
               1
@@ -306,10 +306,8 @@ class UDT(Generic[NodeId]):
         Eg. in the UDT
               1
               |
-              v
               2
             / | \
-           v  v  v
            3  4  5
 
           True == contains_path(1, 2)      [1 is parent of 2 and there is path 1 -> 2]

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -228,7 +228,7 @@ class UDT(Generic[NodeId]):
     def from_edges(cls, edges: Set[Edge[NodeId]]):
         all_node_ids: Set[NodeId] = set(flatten(edges))
 
-        # Create _UDT_Node:s and connect them according to the edge data
+        # Create _UDT_Node:s and add child nodes according to the edge data
         _node_id_dict: Dict[NodeId, _UDT_Node[NodeId]] = {
             node_id: _UDT_Node(node_id) for node_id in all_node_ids
         }

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -393,15 +393,11 @@ class Spans:
 
             if recursive:
                 child_subspans = [s for s in self if is_parent_child(parent, s)]
-                return any(
-                    self.contains_path(s, child, recursive=True) for s in child_subspans
-                )
+                return any(self.contains_path(s, child) for s in child_subspans)
             else:
                 return False
         else:
-            return all(
-                self.contains_path(*ps, recursive=recursive) for ps in pairs(span_chain)
-            )
+            return all(self.contains_path(*ps) for ps in pairs(span_chain))
 
     def _bound_by(self, top: SpanDict, inclusive: bool) -> "Spans":
         """

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -145,7 +145,15 @@ class TreeNode(Generic[NodeId]):
 
 
 # Represent graph edge (n1 -> n2) as tuple (n1, n2).
-# In this case, n1 is "parent node", and n2 is "child node".
+#
+#     n1
+#      |
+#      v
+#     n2
+#
+# Terminology:
+#    n1 is the "parent node";
+#    n2 is the "child node".
 Edge = Tuple[NodeId, NodeId]
 
 
@@ -173,11 +181,11 @@ class TreeSet(Generic[NodeId]):
             node_id: TreeNode(node_id) for node_id in all_node_ids
         }
 
-        for child_id, parent_id in edges:
+        for parent_id, child_id in edges:
             tree_nodes[parent_id].add_child_id(child_id)
 
         # Find the tree root(s) by finding node_id(s) that have no parent.
-        root_ids: Set[NodeId] = all_node_ids - set(child_id for (child_id, _) in edges)
+        root_ids: Set[NodeId] = all_node_ids - set(child_id for (_, child_id) in edges)
 
         return cls(root_ids, all_node_ids, tree_nodes)
 

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -210,9 +210,8 @@ class UDT(Generic[NodeId]):
             / | \  10
            3  4  5
 
-    For example, if we bound the above graph to nodes below 2, we get a graph with
-    nodes 3, 4, 5 and no edges (and 3 root nodes).
-
+    For example, if we bound the above graph to child nodes from 2, we get a graph with
+    nodes 3, 4, 5 and no edges (and three root nodes).
     """
 
     def __init__(

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -178,6 +178,9 @@ class Tree(Generic[NodeId]):
 
     @classmethod
     def from_edges(cls, edges: Set[Edge[NodeId]]):
+        if len(edges) == 0:
+            raise ValueError("Tree should have at least a root node.")
+
         all_node_ids: Set[NodeId] = set(flatten(edges))
 
         # Create TreeNode:s and connect them according to the edge data
@@ -201,6 +204,18 @@ class Tree(Generic[NodeId]):
 
     def __contains__(self, node_id: NodeId) -> bool:
         return node_id in self.all_node_ids
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Tree):
+            return (
+                # -
+                self.edges() == other.edges()
+                and
+                # -
+                self.all_node_ids == other.all_node_ids
+            )
+        else:
+            return False
 
     def _edges_from(self, node_id: NodeId):
         """
@@ -237,7 +252,7 @@ class Tree(Generic[NodeId]):
         bounded_node_ids = set(self._traverse_from(node_id, inclusive=True))
 
         return Tree(
-            root_id={node_id},
+            root_id=node_id,
             all_node_ids=bounded_node_ids,
             node_id_to_treenode={
                 k: self.node_id_to_treenode[k] for k in bounded_node_ids

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_helpers.py
@@ -176,13 +176,18 @@ class _UDT_Node(Generic[NodeId]):
 
 class UDT(Generic[NodeId]):
     """
-    Represent a Union of Directed Trees (UDT), ie., a directed graphs where every node
-    has at most one parent.
+    Represent a "Union of Directed Trees" (UDT) and we use these as directed graphs
+    such that:
 
-    - We will use this for OpenTelemetry spans (where each span has at most one
+     - every node has at most one parent;
+     - there are no cycles.
+
+    Notes:
+    - We will use this to represent OpenTelemetry spans (where each span has at most one
       parent span).
-    - The entire collection of spans logged from a process will have one top span.
-      However, if one bound the log there might be multiple roots.
+    - The entire collection of spans logged from a process will have one top span (
+      so the graph will have one root node). However, if one bound the log there
+      might be multiple root nodes.
 
     Below is example of a UDT with one root (and A -> B indicate that A is parent and
     B is child node)
@@ -286,10 +291,13 @@ class UDT(Generic[NodeId]):
             for child_node_id in self.traverse_from(node_id, inclusive=True):
                 yield child_node_id
 
-    def bound_inclusive(self, node_id: NodeId) -> "UDT":
-        # assumes no cycles
-        assert node_id in self
-        bounded_node_ids = set(self.traverse_from(node_id, inclusive=True))
+    def bound_by(self, node_id: NodeId, inclusive: bool) -> "UDT":
+        """
+        Notes:
+        - assumes no cycles
+        - not currently used
+        """
+        bounded_node_ids = set(self.traverse_from(node_id, inclusive=inclusive))
 
         return UDT(
             all_node_ids=bounded_node_ids,

--- a/workspace/pynb_dag_runner/tests/opentelemetry_helpers/test_spans.py
+++ b/workspace/pynb_dag_runner/tests/opentelemetry_helpers/test_spans.py
@@ -88,8 +88,7 @@ def test__otel__spans__tracing_nested_native_python(dummy_loop_parameter):
     sub2 = one(spans.filter(["name"], "sub2"))
 
     def check_parent_child(parent, child):
-        assert spans.contains_path(parent, child, recursive=True)
-        assert spans.contains_path(parent, child, recursive=False)
+        assert spans.contains_path(parent, child)
         assert is_parent_child(parent, child)
 
     check_parent_child(top, sub1)
@@ -100,8 +99,7 @@ def test__otel__spans__tracing_nested_native_python(dummy_loop_parameter):
     assert not is_parent_child(sub1, top)
 
     # Check that we can find "top -> sub11" relationship in "top -> sub1 -> sub11"
-    assert spans.contains_path(top, sub11, recursive=True)
-    assert not spans.contains_path(top, sub11, recursive=False)
+    assert spans.contains_path(top, sub11)
 
     def check_duration(span, expected_duration_s: float) -> bool:
         return abs(get_duration_s(span) - expected_duration_s) < 0.05
@@ -214,6 +212,6 @@ def test__otel__demo_context_propagation_mechanism():
         assert top_span["attributes"]["parent-attr"] == "foo"
         assert child_span["attributes"]["child-attr"] == "foo-bar"
 
-        assert spans.contains_path(top_span, child_span, recursive=False)
+        assert spans.contains_path(top_span, child_span)
 
     validate_spans(get_test_spans())

--- a/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
+++ b/workspace/pynb_dag_runner/tests/tasks/test_pythonfunction_task.py
@@ -260,7 +260,7 @@ def _get_time_range(spans: Spans, function_id: str, inner: bool):
     return get_duration_range_us(inner_flag_to_span_dict[inner])
 
 
-def test_tasks_run_in_parallel():
+def test__python_function_task__run_in_parallel():
     def get_test_spans():
         with SpanRecorder() as rec:
             tasks = [
@@ -291,7 +291,7 @@ def test_tasks_run_in_parallel():
     validate_spans(get_test_spans())
 
 
-def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
+def test__python_function_task__parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
     def get_test_spans():
         with SpanRecorder() as rec:
             tasks = [
@@ -331,7 +331,7 @@ def test_parallel_tasks_are_queued_based_on_available_ray_worker_cpus():
     validate_spans(get_test_spans())
 
 
-def test_always_failing_task():
+def test__python_function_task__always_failing_task():
     def get_test_spans():
         with SpanRecorder() as rec:
 
@@ -404,7 +404,7 @@ def test_always_failing_task():
     validate_spans(get_test_spans())
 
 
-def test__task_retries__task_is_retried_until_success():
+def test__python_function_task__task_is_retried_until_success():
     def get_test_spans():
         with SpanRecorder() as rec:
 
@@ -606,7 +606,7 @@ def test__task_retries__task_is_retried_until_success():
         },
     ],
 )
-async def test_random_sleep_tasks_with_order_dependencies(
+async def test__python_function_task__random_sleep_tasks_with_order_dependencies(
     dummy_loop_parameter, arg, ray_reinit
 ):
     """

--- a/workspace/pynb_dag_runner/tests/tasks/test_task_opentelemetry_logging.py
+++ b/workspace/pynb_dag_runner/tests/tasks/test_task_opentelemetry_logging.py
@@ -86,7 +86,7 @@ def test__pydar_logger__logged_spans_are_nested():
         sub_span = one(spans.filter(["name"], "sub-span"))
         log_span = one(spans.filter(["name"], "named-value"))
 
-        assert spans.contains_path(top_span, sub_span, log_span, recursive=False)
+        assert spans.contains_path(top_span, sub_span, log_span)
 
     validate_spans(get_test_spans())
 

--- a/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
@@ -169,3 +169,42 @@ def test__tree__built_in_methods(test_tree):
         assert node_id in test_tree
 
     assert not -1 in test_tree
+
+
+def test__tree__bound_inclusive(test_tree: Tree[int]):
+    # Bounding test-tree by node_id=0 (inclusive) should return the same tree
+    tree_bound_0 = test_tree.bound_inclusive(0)
+    assert tree_bound_0 == test_tree
+    assert len(tree_bound_0) == len(test_tree)
+
+    # Bounding by other node_id:s should not return same tree
+    assert not test_tree == test_tree.bound_inclusive(2)
+
+    #
+    # Bounding test-tree by node_id=5 (inclusive) should give tree
+    #
+    #      5
+    #      |
+    #      8
+    #    / | \
+    #  10 11  12
+    #
+    assert test_tree.bound_inclusive(5).all_node_ids == {5, 8, 10, 11, 12}
+    assert test_tree.bound_inclusive(5) == Tree[int].from_edges(
+        {
+            (5, 8),
+            #
+            (8, 10),
+            (8, 11),
+            (8, 12),
+        }
+    )
+
+    # Bounding test-tree by node_id=11 (inclusive) should give tree with only one
+    # element.
+    #
+    # Note that this tree can not be generated from list of edges.
+    tree_bound_11 = test_tree.bound_inclusive(11)
+    assert tree_bound_11.all_node_ids == {11}
+    assert set(tree_bound_11.edges()) == set([])
+    assert len(tree_bound_11) == 1

--- a/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
@@ -206,5 +206,17 @@ def test__tree__bound_inclusive(test_tree: Tree[int]):
     # Note that this tree can not be generated from list of edges.
     tree_bound_11 = test_tree.bound_inclusive(11)
     assert tree_bound_11.all_node_ids == {11}
-    assert set(tree_bound_11.edges()) == set([])
+    assert tree_bound_11.edges() == set([])
     assert len(tree_bound_11) == 1
+
+
+def test__tree__contains_path(test_tree: Tree[int]):
+    assert test_tree.contains_path(0, 1, 2, 4)
+    assert test_tree.contains_path(0, 4)
+    assert test_tree.contains_path(5, 8, 12)
+    assert test_tree.contains_path(5, 12)
+
+    assert not test_tree.contains_path(3, 7)
+    assert not test_tree.contains_path(2, 3)
+    assert not test_tree.contains_path(8, 9)
+    assert not test_tree.contains_path(3, 0)

--- a/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
@@ -183,14 +183,14 @@ def test__graph__built_in_methods(test_udt_fixture: UDT[int]):
         assert not no_node_id in test_udt_fixture
 
 
-def test__graph__bound_inclusive(test_udt_fixture: UDT[int]):
+def test__graph__bound_by(test_udt_fixture: UDT[int]):
     # Bounding test-tree by node_id=0 (inclusive) should return the same tree
-    tree_bound_0 = test_udt_fixture.bound_inclusive(0)
+    tree_bound_0 = test_udt_fixture.bound_by(0, inclusive=True)
     assert tree_bound_0 == test_udt_fixture
     assert len(tree_bound_0) == len(test_udt_fixture)
 
     # Bounding by other node_id:s should not return same tree
-    assert not test_udt_fixture == test_udt_fixture.bound_inclusive(2)
+    assert not test_udt_fixture == test_udt_fixture.bound_by(2, inclusive=True)
 
     #
     # Bounding test-tree by node_id=5 (inclusive) should give tree
@@ -201,8 +201,14 @@ def test__graph__bound_inclusive(test_udt_fixture: UDT[int]):
     #    / | \
     #  10 11  12
     #
-    assert test_udt_fixture.bound_inclusive(5).all_node_ids == {5, 8, 10, 11, 12}
-    assert test_udt_fixture.bound_inclusive(5) == UDT[int].from_edges(
+    assert test_udt_fixture.bound_by(5, inclusive=True).all_node_ids == {
+        5,
+        8,
+        10,
+        11,
+        12,
+    }
+    assert test_udt_fixture.bound_by(5, inclusive=True) == UDT[int].from_edges(
         {
             (5, 8),
             #
@@ -217,10 +223,24 @@ def test__graph__bound_inclusive(test_udt_fixture: UDT[int]):
     #
     # Note: this graph can not be generated from list of edges since there is only
     # one node.
-    tree_bound_11 = test_udt_fixture.bound_inclusive(11)
+    tree_bound_11 = test_udt_fixture.bound_by(11, inclusive=True)
     assert tree_bound_11.all_node_ids == {11}
     assert tree_bound_11.edges() == set([])
     assert len(tree_bound_11) == 1
+
+    # Bounding test-tree by node_id=2 (non-inclusive) should give tree with four
+    # dis-connected components:
+    #
+    #     4     5     6     7
+    #           |           |
+    #           8           9
+    #         / | \
+    #       10 11  12
+    #
+    tree_bound_2 = test_udt_fixture.bound_by(2, inclusive=False)
+    assert tree_bound_2.all_node_ids == {4, 5, 6, 7, 8, 9, 10, 11, 12}
+    assert tree_bound_2.edges() == set([(5, 8), (8, 10), (8, 11), (8, 12), (7, 9)])
+    assert len(tree_bound_2) == 9
 
 
 def test__graph__contains_path(test_udt_fixture: UDT[int]):

--- a/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
@@ -93,7 +93,7 @@ def test_tracing_get_span_id_and_duration():
 
 
 @pytest.fixture
-def tree_edges() -> Set[Tuple[int, int]]:
+def test_tree() -> Tree[int]:
     """
     Test tree:
 
@@ -111,7 +111,7 @@ def tree_edges() -> Set[Tuple[int, int]]:
       10 11  12
     """
 
-    return {
+    edges: Set[Tuple[int, int]] = {
         # (parent_id, child_id)
         (0, 1),
         #
@@ -131,38 +131,41 @@ def tree_edges() -> Set[Tuple[int, int]]:
         (8, 12),
     }
 
+    ts = Tree[int].from_edges(edges)
+    assert set(ts.edges()) == edges
+    return ts
 
-def test__tree__from_edges(tree_edges):
-    ts = Tree[int].from_edges(tree_edges)
 
-    assert ts.all_node_ids == set(range(13))
-    assert ts.root_id == 0
+def test__tree__from_edges(test_tree):
+    assert test_tree.all_node_ids == set(range(13))
+    assert test_tree.root_id == 0
 
     def get_child_ids(node_id: int) -> Set[int]:
-        return set(ts.node_id_to_treenode[node_id].child_ids)
+        return set(test_tree.node_id_to_treenode[node_id].child_ids)
 
     def get_child_ids_from_edges(node_id: int) -> Set[int]:
         return set(
-            child_id for (parent_id, child_id) in tree_edges if parent_id == node_id
+            child_id
+            for (parent_id, child_id) in test_tree.edges()
+            if parent_id == node_id
         )
 
     assert get_child_ids(node_id=0) == {1}
     assert get_child_ids(node_id=1) == {2, 3}
     assert get_child_ids(node_id=2) == {4, 5, 6, 7}
 
-    for node_id in ts.all_node_ids:
+    for node_id in test_tree.all_node_ids:
         assert get_child_ids(node_id) == get_child_ids_from_edges(node_id)
 
 
-def test__tree__built_in_methods(tree_edges):
-    ts = Tree[int].from_edges(tree_edges)
+def test__tree__built_in_methods(test_tree):
 
     # test iteration over elements in tree
-    ts_list = list(iter(ts))
+    ts_list = list(iter(test_tree))
     assert set(ts_list) == set(range(13))
 
     # test element in tree
     for node_id in range(13):
-        assert node_id in ts
+        assert node_id in test_tree
 
-    assert not -1 in ts
+    assert not -1 in test_tree

--- a/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
@@ -179,8 +179,8 @@ def test__graph__built_in_methods(test_udt_fixture: UDT[int]):
     for node_id in range(13):
         assert node_id in test_udt_fixture
 
-    for no_node_id in [-1, "foo"]:
-        assert not no_node_id in test_udt_fixture
+    assert -1 not in test_udt_fixture
+    assert "foo" not in test_udt_fixture  # type: ignore
 
 
 def test__graph__bound_by(test_udt_fixture: UDT[int]):
@@ -228,8 +228,8 @@ def test__graph__bound_by(test_udt_fixture: UDT[int]):
     assert tree_bound_11.edges() == set([])
     assert len(tree_bound_11) == 1
 
-    # Bounding test-tree by node_id=2 (non-inclusive) should give tree with four
-    # dis-connected components:
+    # Bounding test-tree by node_id=2 (non-inclusive) should give union of four
+    # disconnected directed trees:
     #
     #     4     5     6     7
     #           |           |

--- a/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_opentelemetry_helpers.py
@@ -19,7 +19,7 @@ from pynb_dag_runner.opentelemetry_helpers import (
     get_span_exceptions,
     Spans,
     SpanRecorder,
-    TreeSet,
+    Tree,
 )
 from pynb_dag_runner.helpers import one
 
@@ -93,7 +93,7 @@ def test_tracing_get_span_id_and_duration():
 
 
 @pytest.fixture
-def treeset_edges() -> Set[Tuple[int, int]]:
+def tree_edges() -> Set[Tuple[int, int]]:
     """
     Test tree:
 
@@ -132,18 +132,18 @@ def treeset_edges() -> Set[Tuple[int, int]]:
     }
 
 
-def test__treeset__from_edges(treeset_edges):
-    ts = TreeSet[int].from_edges(treeset_edges)
+def test__tree__from_edges(tree_edges):
+    ts = Tree[int].from_edges(tree_edges)
 
     assert ts.all_node_ids == set(range(13))
-    assert ts.root_ids == {0}
+    assert ts.root_id == 0
 
     def get_child_ids(node_id: int) -> Set[int]:
         return set(ts.node_id_to_treenode[node_id].child_ids)
 
     def get_child_ids_from_edges(node_id: int) -> Set[int]:
         return set(
-            child_id for (parent_id, child_id) in treeset_edges if parent_id == node_id
+            child_id for (parent_id, child_id) in tree_edges if parent_id == node_id
         )
 
     assert get_child_ids(node_id=0) == {1}
@@ -152,3 +152,17 @@ def test__treeset__from_edges(treeset_edges):
 
     for node_id in ts.all_node_ids:
         assert get_child_ids(node_id) == get_child_ids_from_edges(node_id)
+
+
+def test__tree__built_in_methods(tree_edges):
+    ts = Tree[int].from_edges(tree_edges)
+
+    # test iteration over elements in tree
+    ts_list = list(iter(ts))
+    assert set(ts_list) == set(range(13))
+
+    # test element in tree
+    for node_id in range(13):
+        assert node_id in ts
+
+    assert not -1 in ts


### PR DESCRIPTION
## Run times mnist demo pipeline "run-all-tests-and-pipeline"-job

### Significant speedup for "Render Gantt and dependency graphs" (16mins -> 42 sec, !!!)

### Before
![image](https://user-images.githubusercontent.com/10188263/179502503-05eef2bd-05f6-426e-b59f-f1d0b6d2a355.png)

### After
![image](https://user-images.githubusercontent.com/10188263/179502595-3cbc7ede-0e73-41df-9df7-de6ac8ce0be6.png)


## Run times for Github action "Run unit tests" step in CI-pipeline for `pynb-dag-runner` repo

### Large variety and no clear speedup.

#### Last 5 runs in `development` branch
- 5:14 #675
- 4:24 #671
- 4:28 #669
- 4:26 #667
- 4:51 #665

#### 5 runs after commit `29900d5` in this PR
- 5:06 #689
- 5:32 #690
- 4:36 #691
- 5:02 #692
- 4:26 #693
